### PR TITLE
Interrupt contact runs when contact has opted out

### DIFF
--- a/core/tasks/handler/worker.go
+++ b/core/tasks/handler/worker.go
@@ -526,6 +526,12 @@ func handleStopEvent(ctx context.Context, rt *runtime.Runtime, event *StopEvent)
 		return err
 	}
 
+	err = models.InterruptContactRuns(ctx, tx, "M", []flows.ContactID{flows.ContactID(event.ContactID)}, event.OccurredOn)
+	if err != nil {
+		tx.Rollback()
+		return err
+	}
+
 	err = models.UpdateContactLastSeenOn(ctx, tx, event.ContactID, event.OccurredOn)
 	if err != nil {
 		tx.Rollback()


### PR DESCRIPTION
The issue happened because the flow run wasn't stopped after the contact opted out. And it took a new opt-in message as a result of the existing run and tries to continue the flow with still blocked contact. I have added changes to stop the contact active session. 

https://communityconnectlabs.atlassian.net/browse/CD-205?atlOrigin=eyJpIjoiMDNlNmYwNmQ1Y2YyNGE4NWJmZDU3MWM3NzA0YTIxZjciLCJwIjoiaiJ9